### PR TITLE
Remove null terminators in Dir response

### DIFF
--- a/dir.go
+++ b/dir.go
@@ -49,7 +49,7 @@ func (oc *OwfsClient) Dir(path string) ([]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read payload from owserver: %s", err)
 			}
-			ret = append(ret, strings.TrimSpace(string(buf)))
+			ret = append(ret, strings.TrimSpace(string(buf[:len(buf)-1])))
 			//log.Println("Response Payload: ", string(buf))
 		} else {
 			break

--- a/read.go
+++ b/read.go
@@ -49,7 +49,7 @@ func (oc *OwfsClient) Read(path string) (string, error) {
 		}
 		return strings.TrimSpace(string(buf)), nil
 	} else {
-		response.dump()
+		//response.dump()
 		return "", fmt.Errorf("Zero length data for device %s", path)
 	}
 }


### PR DESCRIPTION
Hey, I ran into a little bug today where some NULLs were sneaking into the directory list. That was a pain to track down!
I also disabled some debug dumping.
